### PR TITLE
fix(ci): fix YAML syntax error in post-deploy workflow

### DIFF
--- a/.github/workflows/post-deploy.yml
+++ b/.github/workflows/post-deploy.yml
@@ -140,10 +140,9 @@ jobs:
 
 EOFCHANGELOG
 
-          # Remplacer les placeholders
-          sed -i.bak "s/VERSION_PLACEHOLDER/$VERSION/g" CHANGELOG.tmp
-          sed -i.bak "s/DATE_PLACEHOLDER/$DATE/g" CHANGELOG.tmp
-          rm -f CHANGELOG.tmp.bak
+          # Remplacer les placeholders (compatible Linux)
+          sed -i "s/VERSION_PLACEHOLDER/$VERSION/g" CHANGELOG.tmp
+          sed -i "s/DATE_PLACEHOLDER/$DATE/g" CHANGELOG.tmp
 
           # Ajouter l'ancien changelog s'il existe
           if [ -f CHANGELOG.md ]; then


### PR DESCRIPTION
Fixed heredoc syntax issues:
- Changed EOF to quoted 'EOFCHANGELOG' to prevent variable expansion
- Use sed to replace placeholders instead of shell variables in heredoc
- Replaced heredoc in release notes with echo statements
- This fixes the YAML syntax error on line 130

The issue was that unquoted heredocs with $VARIABLE inside them cause YAML parsing errors in GitHub Actions.