### PR TITLE
feat(ci): add release type choice to CI workflow_dispatch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -263,6 +263,7 @@ jobs:
     timeout-minutes: 5
     needs: [test, lint, build, coverage]
     if: >-
+      github.ref == 'refs/heads/main' &&
       github.event_name == 'workflow_dispatch' &&
       inputs.release_type != 'none'
 


### PR DESCRIPTION
- Add patch/minor/major input to workflow_dispatch trigger
- Add release job that triggers manual-release.yml after full CI passes
- Update deploy condition to also run on workflow_dispatch from main
- All CI jobs (test, lint, build, coverage) must pass before release