### PR TITLE
fix(ci): make release label optional in manual-release workflow

### DIFF
--- a/.github/workflows/manual-release.yml
+++ b/.github/workflows/manual-release.yml
@@ -154,8 +154,10 @@ jobs:
             --base main \
             --head "$BRANCH" \
             --title "chore(release): v${VERSION}" \
-            --body-file /tmp/pr_body.md \
-            --label "release")
+            --body-file /tmp/pr_body.md)
+
+          # Add label if it exists (non-blocking)
+          gh pr edit "$PR_URL" --add-label "release" 2>/dev/null || true
 
           echo "pr_url=$PR_URL" >> $GITHUB_OUTPUT
           echo "PR created: $PR_URL"


### PR DESCRIPTION
Label 'release' may not exist in repo. Create PR first, then try adding the label as a non-blocking step.