### PR TITLE
fix(ci): handle existing release branch in manual-release workflow

### DIFF
--- a/.github/workflows/manual-release.yml
+++ b/.github/workflows/manual-release.yml
@@ -100,6 +100,9 @@ jobs:
           VERSION="${{ steps.bump.outputs.new_version }}"
           BRANCH="release/v${VERSION}"
 
+          # Delete remote branch if it already exists (from a previous failed run)
+          git push origin --delete "$BRANCH" 2>/dev/null || true
+
           git checkout -b "$BRANCH"
           git add package.json CHANGELOG.md
 


### PR DESCRIPTION
Delete stale remote release branch before pushing, in case a previous run failed after pushing the branch but before creating the PR.