### PR TITLE
fix(ci): make Discord notification non-blocking in manual-release

### DIFF
--- a/.github/workflows/manual-release.yml
+++ b/.github/workflows/manual-release.yml
@@ -167,6 +167,7 @@ jobs:
 
       - name: Send Discord Notification
         if: success() && env.DISCORD_WEBHOOK != ''
+        continue-on-error: true
         env:
           DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK }}
         run: |


### PR DESCRIPTION
Add continue-on-error so a webhook failure doesn't fail the whole workflow. The PR creation is the critical step.